### PR TITLE
chore: trigger PR checks to register status check names

### DIFF
--- a/.github/.keep
+++ b/.github/.keep
@@ -1,0 +1,1 @@
+# This file exists to trigger the pr-checks workflow so check names register in branch protection.


### PR DESCRIPTION
This PR exists solely to trigger the `pr-checks.yml` workflow so that the `pr-title` and `dependency-audit` status check names register with GitHub and become selectable in branch protection settings.\n\nDo not merge — close after the checks complete.